### PR TITLE
Fix für Links in Zitierungsstilen bei Verwendung von Sonderzeichen

### DIFF
--- a/class_Publikationen.php
+++ b/class_Publikationen.php
@@ -605,15 +605,15 @@ class CRIS_publication extends CRIS_Entity {
     public function __construct($data) {
         parent::__construct($data);
     }
-
+    
     public function insert_quotation_links() {
         /*
          * Enrich APA/MLA quotation by links to publication details (CRIS
          * website) and DOI (if present, applies only to APA).
          */
-
+        
         $doilink = preg_quote("https://dx.doi.org/", "/");
-        $title = preg_quote($this->attributes["cftitle"], "/");
+        $title = preg_quote(Tools::numeric_xml_encode($this->attributes["cftitle"]), "/");
 
         $cristmpl = '<a href="https://cris.fau.de/converis/publicweb/publication/%d" target="_blank">%s</a>';
 
@@ -629,7 +629,13 @@ class CRIS_publication extends CRIS_Entity {
             if (isset($matches[4]))
                 $apalink .= sprintf('<a href="%s" target="_blank">%s</a>', $matches[4], $matches[4]);
         } else {
-            $apalink = $apa;
+            // try to identify DOI at least
+            $splitapa = preg_match("/^(.+)(" . $doilink . ".+)?$/Uu", $apa, $matches);
+            if ($splitapa === 1) {
+                $apalink = $matches[1] . \
+                    sprintf('<a href="%s" target="_blank">%s</a>', $matches[2], $matches[2]);
+            } else
+                $apalink = $apa;
         }
 
         $this->attributes["quotationapalink"] = $apalink;

--- a/class_Tools.php
+++ b/class_Tools.php
@@ -465,4 +465,40 @@ class Tools {
         return $date;
     }
 
+    public static function numeric_xml_encode($text, $double_encode=true){
+        /*
+         * Deliver numerically encoded XML representation of special characters.
+         * E.g. use &#8211; instead of &ndash;
+         * 
+         * Adopted from user-contributed notes of 
+         * http://php.net/manual/de/function.htmlentities.php
+         * 
+         * @param string $text Input text
+         * @param bool $double_encode flag for double encoding (defaults to true)
+         * 
+         * @return string $encoded Encoded text representation
+         */
+        
+        if (!$double_encode)
+            $text = html_entity_decode(stripslashes($text), ENT_QUOTES, 'UTF-8');
+
+        // array of chars (multibyte aware)
+        $mbchars = preg_split('/(?<!^)(?!$)/u', $text);
+        
+        $encoded = '';
+        foreach ($mbchars as $char){
+            $o = ord($char);
+            if ( (strlen($char) > 1) || /* multi-byte [unicode] */
+                ($o <32 || $o > 126) || /* <- control / latin weird os -> */
+                ($o >33 && $o < 40) ||/* quotes + ambersand */
+                ($o >59 && $o < 63) /* html */
+            ) {
+                // convert to numeric entity
+                $char = mb_encode_numericentity($char, 
+                                        array(0x0, 0xffff, 0, 0xffff), 'UTF-8');
+            }
+            $encoded .= $char;
+        }
+        return $encoded;
+    }
 }


### PR DESCRIPTION
Wir haben die Generierung der Zitationstrings umgestellt, so dass Sonderzeichen nun encoded über den Webservice ausgeliefert werden. Damit ist ein Vergleich mit dem Originaltitel nicht mehr möglich, die RegEx "trifft" nicht und die Links werden nicht eingefügt ([Beispiel](https://www.wirtschaftstheorie.wiso.uni-erlangen.de/de/forschung/artikel-in-fachzeitschriften/)).

Die Sonderzeichen werden in CRIS numerisch encoded, PHP verwendet allerdings primär Entity-Namen (Bsp: `&#8211;` vs. `&ndash;`). Daher musste eine Funktion für PHP her, welche auch numerische Encodings für den Vergleich liefert.

Wenn auch hier der Vergleich fehlschlägt, wird noch versucht, wenigstens den DOI zu verlinken.