### PR TITLE
Check if imgs['relation right seq'] is countable for research areas

### DIFF
--- a/includes/Forschungsbereiche.php
+++ b/includes/Forschungsbereiche.php
@@ -266,7 +266,7 @@ class Forschungsbereiche
                 $singlefield .= "<h2>" . $title . "</h2>";
             }
 
-            if (count($imgs['relation right seq'])) {
+            if (is_countable($imgs['relation right seq']) && count($imgs['relation right seq'])) {
                 $singlefield .= "<div class=\"cris-image wp-caption " . $param['image_align'] .  "\">";
                 foreach ($imgs['relation right seq'] as $img) {
                     // foreach ($imgs as $img) {


### PR DESCRIPTION
We are currently getting PHP errors for some of our research areas:
```
Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in ....../includes/Forschungsbereiche.php:269
```
Example Shortcode that causes the error:
```
[cris show=fields field=329057965 hide="title"]
```

This fix checks if `$imgs['relation right seq']` is countable before passing it to `count(...)`.