### PR TITLE
Rename `fullscreen` shortcode attribute to `fullscreenlink`

### DIFF
--- a/fau-cris.php
+++ b/fau-cris.php
@@ -19,7 +19,7 @@ use RRZE\Cris\Sync;
 /**
  * Plugin Name: FAU CRIS
  * Description: Anzeige von Daten aus dem FAU-Forschungsportal CRIS in WP-Seiten
- * Version: 3.29.2
+ * Version: 3.29.3
  * Author: RRZE-Webteam
  * Author URI: http://blogs.fau.de/webworking/
  * Text Domain: fau-cris
@@ -80,7 +80,7 @@ class FAU_CRIS
     /**
      * Get Started
      */
-    const version = '3.29.2';
+    const version = '3.29.3';
     const option_name = '_fau_cris';
     const version_option_name = '_fau_cris_version';
     const textdomain = 'fau-cris';
@@ -1142,13 +1142,14 @@ public static function options_fau_cris(): void
                 return $liste->awardsNachJahr($parameter);
             }
             return $liste->awardsListe($parameter, '');
-        } elseif (isset($parameter['show']) && $parameter['show'] == 'map') {
-            // Visualization (Maps)
-            $vis = new Visualization($parameter['mapid'], $page_lang, $parameter['size']);
+        } elseif (isset($parameter['show']) && ($parameter['show'] == 'visualisation' || $parameter['show'] == 'map')) {
+            // Visualization (Maps and Networks)
+            $vis_id = $parameter['visualisationid'] ?: $parameter['mapid'];
+            $vis = new Visualization($vis_id, $page_lang, $parameter['size'], $parameter['fullscreen']);
             if ($vis->error && is_wp_error($vis->error)) {
                 return '<div class="cris-error">' . $vis->error->get_error_message() . '</div>';
             }
-            return $vis->display($parameter['fullscreen']);
+            return $vis->display();
         } else {
             // Publications
             $liste = new Publikationen($parameter['entity'], $parameter['entity_id'], $parameter['name_order_plugin'], $page_lang, $parameter['display_language']);
@@ -1327,7 +1328,8 @@ public static function options_fau_cris(): void
             'publicationsum'=>'',
             'useprojpubls'=>'false',
             'listtype'=>'ul',
-            'mapid' => '',
+            'visualisationid' => '',
+            'mapid' => '', // Backwards compatibility
             'size' => 'm',
             'fullscreen' => 'false'
         ];
@@ -1401,7 +1403,8 @@ public static function options_fau_cris(): void
         $sc_param['publicationsum'] = sanitize_text_field($publicationsum);
         $sc_param['useprojpubls'] = strtolower(sanitize_text_field($useprojpubls));
         $sc_param['listtype'] = strtolower(sanitize_text_field($listtype));
-        $sc_param['mapid'] = sanitize_text_field($mapid);
+        $sc_param['visualisationid'] = sanitize_text_field($visualisationid);
+        $sc_param['mapid'] = sanitize_text_field($mapid); // Backwards compatibility
         $sc_param['size'] = in_array(sanitize_text_field($size), ['s', 'm', 'l']) ? sanitize_text_field($size) : 'm';
         $sc_param['fullscreen'] = in_array(strtolower(sanitize_text_field($fullscreen)), ['true', '1', 'yes']) ? true : false;
         switch ($sortby) {

--- a/fau-cris.php
+++ b/fau-cris.php
@@ -19,7 +19,7 @@ use RRZE\Cris\Sync;
 /**
  * Plugin Name: FAU CRIS
  * Description: Anzeige von Daten aus dem FAU-Forschungsportal CRIS in WP-Seiten
- * Version: 3.29.3
+ * Version: 3.29.4
  * Author: RRZE-Webteam
  * Author URI: http://blogs.fau.de/webworking/
  * Text Domain: fau-cris
@@ -80,7 +80,7 @@ class FAU_CRIS
     /**
      * Get Started
      */
-    const version = '3.29.3';
+    const version = '3.29.4';
     const option_name = '_fau_cris';
     const version_option_name = '_fau_cris_version';
     const textdomain = 'fau-cris';
@@ -1145,7 +1145,7 @@ public static function options_fau_cris(): void
         } elseif (isset($parameter['show']) && ($parameter['show'] == 'visualisation' || $parameter['show'] == 'map')) {
             // Visualization (Maps and Networks)
             $vis_id = $parameter['visualisationid'] ?: $parameter['mapid'];
-            $vis = new Visualization($vis_id, $page_lang, $parameter['size'], $parameter['fullscreen']);
+            $vis = new Visualization($vis_id, $page_lang, $parameter['size'], $parameter['fullscreenlink']);
             if ($vis->error && is_wp_error($vis->error)) {
                 return '<div class="cris-error">' . $vis->error->get_error_message() . '</div>';
             }
@@ -1331,7 +1331,7 @@ public static function options_fau_cris(): void
             'visualisationid' => '',
             'mapid' => '', // Backwards compatibility
             'size' => 'm',
-            'fullscreen' => 'false'
+            'fullscreenlink' => 'false'
         ];
 
         // Attributes
@@ -1406,7 +1406,7 @@ public static function options_fau_cris(): void
         $sc_param['visualisationid'] = sanitize_text_field($visualisationid);
         $sc_param['mapid'] = sanitize_text_field($mapid); // Backwards compatibility
         $sc_param['size'] = in_array(sanitize_text_field($size), ['s', 'm', 'l']) ? sanitize_text_field($size) : 'm';
-        $sc_param['fullscreen'] = in_array(strtolower(sanitize_text_field($fullscreen)), ['true', '1', 'yes']) ? true : false;
+        $sc_param['fullscreenlink'] = in_array(strtolower(sanitize_text_field($fullscreenlink)), ['true', '1', 'yes']) ? true : false;
         switch ($sortby) {
             case 'created':
                 $sc_param['sortby'] = 'updatedon';

--- a/includes/Visualization.php
+++ b/includes/Visualization.php
@@ -16,7 +16,7 @@ class Visualization
     private float $latitude = 0;
     private float $longitude = 0;
     private int $zoom = 4;
-    private bool $fullscreen = false;
+    private bool $fullscreenlink = false;
     public \WP_Error|null $error = null;
 
     private const SIZE_MAP = [
@@ -35,13 +35,13 @@ class Visualization
      * @param string $vis_id Visualization ID (mapid)
      * @param string $page_lang Page language (unused, kept for backwards compatibility)
      * @param string $size Size option ('s', 'm', or 'l')
-     * @param bool $fullscreen Enable fullscreen button (default: false)
+     * @param bool $fullscreenlink Enable fullscreen link button (default: false)
      */
-    public function __construct(string $vis_id = '', string $page_lang = 'de', string $size = self::DEFAULT_SIZE, bool $fullscreen = false)
+    public function __construct(string $vis_id = '', string $page_lang = 'de', string $size = self::DEFAULT_SIZE, bool $fullscreenlink = false)
     {
         $this->vis_id = sanitize_text_field($vis_id);
         $this->size = isset(self::SIZE_MAP[$size]) ? $size : self::DEFAULT_SIZE;
-        $this->fullscreen = $fullscreen;
+        $this->fullscreenlink = $fullscreenlink;
 
         if (empty($this->vis_id)) {
             $this->error = new \WP_Error(
@@ -131,13 +131,11 @@ class Visualization
 
     /**
      * Render the visualization
-     * 
-     * @param bool $fullscreen Override fullscreen setting (deprecated, use constructor parameter)
+     *
      * @return string HTML output or error message
      */
-    public function display(bool $fullscreen = false): string
+    public function display(): string
     {
-        // Return error if visualization is invalid
         if ($this->error) {
             return sprintf(
                 '<div class="cris-error">%s: %s</div>',
@@ -146,9 +144,8 @@ class Visualization
             );
         }
 
-        // Return iframe with optional fullscreen button
         $html = $this->render_iframe();
-        if ($this->fullscreen) {
+        if ($this->fullscreenlink) {
             $html .= $this->render_fullscreen_button();
         }
         return $html;

--- a/includes/Visualization.php
+++ b/includes/Visualization.php
@@ -3,15 +3,20 @@ namespace RRZE\Cris;
 defined('ABSPATH') || exit;
 
 /**
- * Visualization class for rendering interactive maps from data.fau.de
+ * Visualization class for rendering interactive maps and networks from data.fau.de
  * 
  * Renders visualizations via direct iframe src to data.fau.de/visualisation/{mapid}.html
- * No API fetching required - direct URL approach
+ * Fetches metadata from CRIS API to determine visualization type and parameters
  */
 class Visualization
 {
     private string $vis_id;
     private string $size;
+    private string $vis_type = '';
+    private float $latitude = 0;
+    private float $longitude = 0;
+    private int $zoom = 4;
+    private bool $fullscreen = false;
     public \WP_Error|null $error = null;
 
     private const SIZE_MAP = [
@@ -21,6 +26,8 @@ class Visualization
     ];
 
     private const DEFAULT_SIZE = 'm';
+    private const VIS_TYPE_MAP = 'visualisation_type_geographic';
+    private const VIS_TYPE_NETWORK = 'visualisation_type_cooperationnetwork';
 
     /**
      * Constructor
@@ -28,31 +35,109 @@ class Visualization
      * @param string $vis_id Visualization ID (mapid)
      * @param string $page_lang Page language (unused, kept for backwards compatibility)
      * @param string $size Size option ('s', 'm', or 'l')
+     * @param bool $fullscreen Enable fullscreen button (default: false)
      */
-    public function __construct(string $vis_id = '', string $page_lang = 'de', string $size = self::DEFAULT_SIZE)
+    public function __construct(string $vis_id = '', string $page_lang = 'de', string $size = self::DEFAULT_SIZE, bool $fullscreen = false)
     {
         $this->vis_id = sanitize_text_field($vis_id);
         $this->size = isset(self::SIZE_MAP[$size]) ? $size : self::DEFAULT_SIZE;
+        $this->fullscreen = $fullscreen;
 
         if (empty($this->vis_id)) {
             $this->error = new \WP_Error(
                 'cris-vis-id-error',
                 __('Visualization ID is required', 'fau-cris')
             );
+            return;
         }
+
+        // Fetch metadata from CRIS API
+        $this->fetch_metadata();
     }
 
+    /**
+     * Fetch visualization metadata from CRIS API
+     * 
+     * @return void
+     */
+    private function fetch_metadata(): void
+    {
+        try {
+            $webservice = new Webservice();
+            $filter = new Filter([]);
+            
+            // Note: base_uri already includes "infoobject/", so we only need the action path
+            $result = $webservice->get('get/visualization/' . $this->vis_id, $filter);
+            
+            if (is_wp_error($result)) {
+                $this->error = $result;
+                return;
+            }
 
+            // $result should be an array of infoObject elements
+            if (!is_array($result)) {
+                $result = [$result];
+            }
+
+            if (empty($result)) {
+                $this->error = new \WP_Error(
+                    'cris-vis-not-found',
+                    __('Visualization not found', 'fau-cris')
+                );
+                return;
+            }
+
+            $infoObject = $result[0];
+
+            // Parse attributes
+            foreach ($infoObject->attribute as $attribute) {
+                $attr_name = (string) $attribute['name'];
+                $attr_value = (string) $attribute->data;
+                $attr_additional = (string) $attribute->additionalInfo;
+
+                switch (strtolower($attr_name)) {
+                    case 'dynamicselector':
+                        $this->vis_type = $attr_additional;
+                        break;
+                    case 'zoom':
+                        // Extract zoom level from additionalInfo (e.g., "visualisation_zoom_3" -> 3)
+                        if (preg_match('/zoom_(\d+)/', $attr_additional, $matches)) {
+                            $this->zoom = (int) $matches[1];
+                        }
+                        break;
+                    case 'originlatitude':
+                        $this->latitude = (float) $attr_value;
+                        break;
+                    case 'originlongitude':
+                        $this->longitude = (float) $attr_value;
+                        break;
+                }
+            }
+
+            // Validate that we got required metadata
+            if (empty($this->vis_type)) {
+                $this->error = new \WP_Error(
+                    'cris-vis-type-error',
+                    __('Visualization type could not be determined', 'fau-cris')
+                );
+            }
+        } catch (\Exception $e) {
+            $this->error = new \WP_Error(
+                'cris-vis-fetch-error',
+                sprintf(__('Error fetching visualization data: %s', 'fau-cris'), $e->getMessage())
+            );
+        }
+    }
 
     /**
      * Render the visualization
      * 
-     * @param bool $fullscreen Currently unused (reserved for future use)
+     * @param bool $fullscreen Override fullscreen setting (deprecated, use constructor parameter)
      * @return string HTML output or error message
      */
     public function display(bool $fullscreen = false): string
     {
-        // Return error if vis_id is invalid
+        // Return error if visualization is invalid
         if ($this->error) {
             return sprintf(
                 '<div class="cris-error">%s: %s</div>',
@@ -61,19 +146,23 @@ class Visualization
             );
         }
 
-        // Return iframe with fullscreen button
-        return $this->render_iframe() . $this->render_fullscreen_button();
+        // Return iframe with optional fullscreen button
+        $html = $this->render_iframe();
+        if ($this->fullscreen) {
+            $html .= $this->render_fullscreen_button();
+        }
+        return $html;
     }
 
     /**
-     * Render iframe with direct src to visualization URL
+     * Render iframe with correct src based on visualization type
      * 
      * @return string iframe HTML
      */
     private function render_iframe(): string
     {
         $height = self::SIZE_MAP[$this->size];
-        $url = 'https://data.fau.de/visualisation/' . esc_attr($this->vis_id) . '.html';
+        $url = $this->get_url();
 
         return sprintf(
             '<div class="cris-visualization cris-vis-size-%s">
@@ -101,7 +190,7 @@ class Visualization
      */
     private function render_fullscreen_button(): string
     {
-        $url = 'https://data.fau.de/visualisation/' . esc_attr($this->vis_id) . '.html';
+        $url = $this->get_url();
 
         return sprintf(
             '<div class="cris-visualization-fullscreen-btn" style="text-align: center; margin-top: 15px;">
@@ -138,7 +227,50 @@ class Visualization
         if ($this->error) {
             return '';
         }
-        return 'https://data.fau.de/visualisation/' . $this->vis_id . '.html';
+
+        $base_url = 'https://data.fau.de/visualisation/' . $this->vis_id . '.html';
+
+        // Add parameters for map type
+        if ($this->vis_type === self::VIS_TYPE_MAP) {
+            $base_url .= sprintf(
+                '?isStart=0&zoom=%d&lat=%f&lng=%f',
+                $this->zoom,
+                $this->latitude,
+                $this->longitude
+            );
+        }
+
+        return $base_url;
+    }
+
+    /**
+     * Get visualization type
+     * 
+     * @return string Visualization type
+     */
+    public function get_type(): string
+    {
+        return $this->vis_type;
+    }
+
+    /**
+     * Check if visualization is a map
+     * 
+     * @return bool
+     */
+    public function is_map(): bool
+    {
+        return $this->vis_type === self::VIS_TYPE_MAP;
+    }
+
+    /**
+     * Check if visualization is a network
+     * 
+     * @return bool
+     */
+    public function is_network(): bool
+    {
+        return $this->vis_type === self::VIS_TYPE_NETWORK;
     }
 
     /**


### PR DESCRIPTION
The attribute opens the visualization in a new tab rather than
toggling iframe fullscreen, so the old name was misleading. Also
removed the unused override parameter from Visualization::display().